### PR TITLE
Refactor currency conditional

### DIFF
--- a/catalog/model/extension/payment/paystack.php
+++ b/catalog/model/extension/payment/paystack.php
@@ -18,10 +18,13 @@ class ModelExtensionPaymentPaystack extends Model
         }
         
         // Paystack only switches NGN, GHS and USD for now
-        if ($status 
-            && ((strtoupper($this->config->get('config_currency')) =='NGN')
-            || (strtoupper($this->config->get('config_currency')) =='GHS')
-            || (strtoupper($this->config->get('config_currency')) =='USD'))
+        if ($status && (!in_array(
+            strtoupper($this->config->get('config_currency')), 
+            [ 
+                'NGN',
+                'GHS'
+            ]
+        ))
         ) {
             $status = true;
         }


### PR DESCRIPTION
This fixes an error where Paystack was returning $status = false
regardless of currency.

This makes it easier to update with more currencies in the future