### PR TITLE
Fix issue where transactions were not verifying

### DIFF
--- a/catalog/controller/extension/payment/paystack.php
+++ b/catalog/controller/extension/payment/paystack.php
@@ -42,6 +42,7 @@ class ControllerExtensionPaymentPaystack extends Controller
                 'http'=>array(
                 'method'=>"GET",
                 'header'=>"Authorization: Bearer " .  $skey,
+                'user-agent'=>"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
                 )
             )
         );


### PR DESCRIPTION
Because some servers do not send a recognizable user agent while making requests, they get blocked by CloudFlare leading to transactions not verifying. This fixes this issue by sending a Chrome UA with each request